### PR TITLE
Do not display secrets in non-password input field

### DIFF
--- a/src/components/AccessByPrivatekey.js
+++ b/src/components/AccessByPrivatekey.js
@@ -81,7 +81,7 @@ class AccessByPrivateKey extends Component<Props> {
         </p>
         <Input
           label="Klaytn Wallet Key or Private Key"
-          type="text"
+          type="password"
           autoFocus
           name="privatekey"
           className="AccessByPrivatekey__input"

--- a/src/components/InputCopy.js
+++ b/src/components/InputCopy.js
@@ -9,7 +9,8 @@ class InputCopy extends Component<Props> {
   state = {
     isCopied: false,
     showPassword: false,
-    bullet: madeBulletString(112),
+    bulletOneLine: madeBulletString(66),
+    bulletTwoLine: madeBulletString(112),
   }
 
   copy = () => {
@@ -31,8 +32,13 @@ class InputCopy extends Component<Props> {
       showPassword: !this.state.showPassword,
     })
   }
+
+  showBullet = () => {
+    return this.eye && !this.showPassword;
+  }
+
   render() {
-    const { isCopied, showPassword, bullet } = this.state
+    const { isCopied, showPassword, bulletOneLine, bulletTwoLine } = this.state
     const {
       className,
       name,
@@ -59,7 +65,7 @@ class InputCopy extends Component<Props> {
           </Tooltip>}
 
         <div className={cx('InputCopy__inputWrapper', { 'InputCopy__inputWrapper__type2': subName, 'InputCopy__inputWrapper__type3': styleType })}>
-        {eye && (
+          {eye && (
             <button
               className={cx('InputCopy__eye', {
                 'InputCopy__eye--show': !showPassword,
@@ -73,14 +79,25 @@ class InputCopy extends Component<Props> {
           <input
             ref={($input) => this.$input = $input}
             name={name}
-            type={eye
-                ? (!showPassword ? 'password' : 'text')
-                : 'text'}
+            type="password"
             value={value}
-            className={cx('InputCopy__input', { 'hide': styleType == 'twoLine' })}
+            className="hide"
             readOnly
           />
-          {styleType == 'twoLine' && <textarea className={cx('textarea__Copy', {'textarea__password': eye && !showPassword })} value={ eye && !showPassword ? bullet : value} readOnly></textarea>}
+          {styleType != 'twoLine' && (
+            <div
+             className={cx('InputCopy__oneLine', { 'InputCopy__bullet': eye && !showPassword })}
+            >
+              {eye && !showPassword ? bulletOneLine : value}
+            </div>
+          )}
+          {styleType == 'twoLine' && (
+            <div
+             className={cx('InputCopy__twoLine', { 'InputCopy__bullet': eye && !showPassword })}
+            >
+            {eye && !showPassword ? bulletTwoLine : value}
+            </div>
+          )}
           
           <button
             className={cx('InputCopy__copyButton', {

--- a/src/components/InputCopy.js
+++ b/src/components/InputCopy.js
@@ -5,6 +5,20 @@ import { copy, madeBulletString } from 'utils/misc'
 import Tooltip from 'components/Tooltip'
 import './InputCopy.scss'
 
+/*
+ * A read-only text field.
+ *
+ * - eye: If nonempty, the contents are hidden by default and appears when
+ *   the user clicks an eye icon
+ * - styleType:
+ *   - "": Value and COPY buttons are on the same line
+ *   - "oneLine": Value takes up one line and COPY button is placed below the line
+ *   - "twoLine": Value takes up two lines and COPY button is placed below the lines
+ *
+ * As opposed to its name 'InputCopy', the values are rendered inside <div>
+ * for security reason related to CVE-2022-32969 (browser information leak via
+ * non-password input field)
+ */
 class InputCopy extends Component<Props> {
   state = {
     isCopied: false,

--- a/src/components/InputCopy.js
+++ b/src/components/InputCopy.js
@@ -38,12 +38,7 @@ class InputCopy extends Component<Props> {
       name,
       value,
       label,
-      onChange,
-      onKeyPress,
-      placeholder,
       width,
-      disabled,
-      err,
       eye,
       isTooltip,
       tooltipText,
@@ -82,11 +77,7 @@ class InputCopy extends Component<Props> {
                 ? (!showPassword ? 'password' : 'text')
                 : 'text'}
             value={value}
-            onChange={onChange}
-            onKeyPress={onKeyPress}
-            placeholder={placeholder}
-            disabled={disabled}
-            className={cx('InputCopy__input', { 'InputCopy--err': err, 'hide': styleType == 'twoLine' })}
+            className={cx('InputCopy__input', { 'hide': styleType == 'twoLine' })}
             readOnly
           />
           {styleType == 'twoLine' && <textarea className={cx('textarea__Copy', {'textarea__password': eye && !showPassword })} value={ eye && !showPassword ? bullet : value} readOnly></textarea>}

--- a/src/components/InputCopy.scss
+++ b/src/components/InputCopy.scss
@@ -13,11 +13,6 @@
   &.not__margin { 
     margin-bottom: 4px;
   }
-  &.textarea__show .textarea__Copy {
-    @include font-style('caption-alert');
-    color: $Red;
-    padding: 7px 8px 8px;
-  }
 }
 
 .InputCopy__inputWrapper {
@@ -58,27 +53,32 @@
     opacity: 0;
     z-index: -1;
   }
-  .textarea__Copy {
-    position: relative;
-    width: 100%;
-    padding: 7px 37px 6px 8px;
-    height: 50px;
-    border: none;
-    resize: none;
-    color: $dark-blue-grey;
-    background-color: #f0f2fc;
-    outline: none;
-    z-index: 1;
-    @include font-style('body');
-    &.textarea__password {
-      font-size: 18px;
-      line-height: 1.1;
-    }
-  }
-  
 }
 
-.InputCopy__input {
+.InputCopy__twoLine {
+  @include font-style('body');
+  text-overflow: ellipsis;
+  color: $dark-blue-grey;
+  background-color: #f0f2fc;
+  outline: 0;
+  border: 0;
+  width: 100%;
+  height: 30px;
+  line-height: normal;
+  height: 50px;
+  display: block;
+  padding: 7px 37px 6px 8px;
+  word-break: break-all;
+
+  &::placeholder {
+    color: $middle-blue-grey;
+  }
+
+  &:-webkit-autofill {
+    background-color: transparent;
+  }
+}
+.InputCopy__oneLine {
   @include font-style('body');
   text-overflow: ellipsis;
   color: $dark-blue-grey;
@@ -100,7 +100,10 @@
     background-color: transparent;
   }
 }
-.InputCopy__eye +.InputCopy__input  {
+.InputCopy__bullet {
+  font-size: 18px;
+}
+.InputCopy__eye +.InputCopy__oneLine {
   padding-right: 30px;
 }
 .InputCopy__copyButton {

--- a/src/components/MyWallet.js
+++ b/src/components/MyWallet.js
@@ -134,7 +134,6 @@ class MyWallet extends Component<Props> {
               )}
               styleType="pullSize"
               readOnly
-              autoFocus
               eye
             />
             <InputCopy
@@ -152,7 +151,6 @@ class MyWallet extends Component<Props> {
               )}
               styleType="twoLine"
               readOnly
-              autoFocus
               eye
             />
             <div className="MyWallet__bottom">

--- a/src/components/MyWallet.js
+++ b/src/components/MyWallet.js
@@ -28,7 +28,6 @@ class MyWallet extends Component<Props> {
 
   state = {
     balance: null,
-    hidePrivateKey: true,
     klayAccounts : sessionStorage.getItem('address'),
     showPopup: false,
 
@@ -58,9 +57,6 @@ class MyWallet extends Component<Props> {
   //   console.log(address)
   //   return caver.utils.hexToUtf8(address)
   // }
-  togglePrivateKey = () => {
-    this.setState({ hidePrivateKey: !this.state.hidePrivateKey })
-  }
   HRADataChange = () => {
     let address = sessionStorage.getItem('address')
     if(address){
@@ -91,7 +87,7 @@ class MyWallet extends Component<Props> {
     this.setState({ showPopup: false })
   }
   render() {
-    const { hidePrivateKey, klayAccounts, showPopup } = this.state
+    const { klayAccounts, showPopup } = this.state
     const { isTokenAddMode } = this.props
     return !!this.wallet && (
       <div className={cx('MyWallet', {
@@ -127,9 +123,7 @@ class MyWallet extends Component<Props> {
               className="MyWallet__Input"
               name="privateKey"
               label="Private Key"
-              onLabelClick={this.togglePrivateKey}
               labelClassName="MyWallet__hideButton"
-              type={hidePrivateKey ? 'password' : 'text'}
               value={this.wallet.privateKey}
               isTooltip={true}
               tooltipText={(
@@ -147,9 +141,7 @@ class MyWallet extends Component<Props> {
               className="MyWallet__Input"
               name="Klaytn Wallet Key"
               label="Klaytn Wallet Key"
-              onLabelClick={this.togglePrivateKey}
               labelClassName="MyWallet__hideButton"
-              type={hidePrivateKey ? 'password' : 'text'}
               value={this.privatekeySet()}
               isTooltip={true}
               tooltipText={(

--- a/src/components/MyWallet.js
+++ b/src/components/MyWallet.js
@@ -123,7 +123,6 @@ class MyWallet extends Component<Props> {
               className="MyWallet__Input"
               name="privateKey"
               label="Private Key"
-              labelClassName="MyWallet__hideButton"
               value={this.wallet.privateKey}
               isTooltip={true}
               tooltipText={(
@@ -132,7 +131,7 @@ class MyWallet extends Component<Props> {
                   <p>Please store your private key securely, as its compromise can lead to loss of control of your account and assets within the account.</p>
                 </Fragment>
               )}
-              styleType="pullSize"
+              styleType="oneLine"
               readOnly
               eye
             />
@@ -140,7 +139,6 @@ class MyWallet extends Component<Props> {
               className="MyWallet__Input"
               name="Klaytn Wallet Key"
               label="Klaytn Wallet Key"
-              labelClassName="MyWallet__hideButton"
               value={this.privatekeySet()}
               isTooltip={true}
               tooltipText={(

--- a/src/components/WalletCreation1.scss
+++ b/src/components/WalletCreation1.scss
@@ -29,3 +29,21 @@
     
   }
 }
+
+.WalletCreationStep3__Info {
+  margin-bottom: 60px;
+}
+
+.WalletCreationStep3__Input {
+  vertical-align: middle;
+  margin-bottom: 40px;
+  .InputCopy__label {
+    display: inline-block;
+  }
+  .InputCopy__oneLine {
+    font-size: 12px;
+    &.InputCopy__bullet {
+      font-size: 18px;
+    }
+  }
+}

--- a/src/components/WalletCreationStep3.js
+++ b/src/components/WalletCreationStep3.js
@@ -67,17 +67,38 @@ class WalletCreationStep3 extends Component<Props> {
           </Fragment>
         )}
         render={() => (
-          <div className="input__box">
+          <div className="WalletCreationStep3__Info">
             <InputCopy
-              value={privateKey}
+              className="WalletCreationStep3__Input"
+              name="privateKey"
               label="Private Key"
+              value={privateKey}
+              isTooltip={true}
+              tooltipText={(
+                <Fragment>
+                  <p>This refers to the 32 byte private key commonly used in public key cryptography (following the same format as in Ethereum); it is used for transaction signing.</p>
+                  <p>Please store your private key securely, as its compromise can lead to loss of control of your account and assets within the account.</p>
+                </Fragment>
+              )}
+              styleType="oneLine"
+              readOnly
+              eye
             />
             <InputCopy
-              value={this.madeWalletKey()}
-              className="textarea__show"
+              className="WalletCreationStep3__Input"
+              name="Klaytn Wallet Key"
               label="Klaytn Wallet Key"
-              clickEvent={this.togglePrivateKey}
+              value={this.madeWalletKey()}
+              isTooltip={true}
+              tooltipText={(
+                <Fragment>
+                  <p>Klaytn Wallet Key contains important information that users need in order to access their account: the private key AND the account address. Users with custom address accounts are required to use Klaytn Wallet Key when signing in to services on Klaytn.</p>
+                  <p>Please note that Klaytn Wallet Key should NOT be used for transaction signing; it is for sign-in purpose only.</p>
+                </Fragment>
+              )}
               styleType="twoLine"
+              readOnly
+              eye
             />
             </div>
         )}


### PR DESCRIPTION
## Proposed changes

Fixes https://github.com/klaytn/klaytnwallet/issues/90.

- Hide secrets by default
  - `WalletCreationStep3`: The private key and the Klaytn wallet key are hidden by default.
  - `AccessByPrivateKey`: The private key input field is now a "password" type
- Display secrets in `<div>` instead of `<input type="text">`
  - When hidden, values are replaced by bullet characters.
  - Affects `WalletCreationStep3` and `MyWallet`
- Add tooltips in `WalletCreationStep3` to match `MyWallet`

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING](https://github.com/klaytn/klaytnwallet/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytnwallet)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
