### PR TITLE
Fix sendTransaction bug when calling VALUE_TRANSFER

### DIFF
--- a/src/components/WalletTransfer2.js
+++ b/src/components/WalletTransfer2.js
@@ -199,7 +199,7 @@ class WalletTransfer2 extends Component<Props> {
     await caver.klay.sendTransaction({
       type: setType,
       from: this.HRADataChange(),
-      data:'',
+      data: setType === 'SMART_CONTRACT_EXECUTION' ? '' : undefined,
       to,
       value: caver.utils.toWei(value, 'ether'),
       gas: gas || DEFAULT_KLAY_TRANSFER_GAS,


### PR DESCRIPTION
## Proposed changes

- Since 'data' field for 'VALUE_TRANFER' should be undefined, make it undefined when the type is 'VALUE_TRNASFER'. (You can check this: [caver-js](https://github.com/klaytn/caver-js/blob/dev/packages/caver-core-helpers/src/validateFunction.js#L352))

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING](https://github.com/klaytn/klaytnwallet/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytnwallet)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
